### PR TITLE
Pulling bittorrent changes into transmission

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Copyright (c) 2010 BitTorrent, Inc.
 
 uTP is a TCP-like implementation of [LEDBAT][ledbat] documented as a BitTorrent
-extension in [BEP-29][bep29]. uTP provides provides reliable, ordered delivery
+extension in [BEP-29][bep29]. uTP provides reliable, ordered delivery
 while maintaining minimum extra delay. It is implemented on top of UDP to be
 cross-platform and functional today. As a result, uTP is the primary transport
 for uTorrent peer-to-peer connections.

--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -749,7 +749,7 @@ void UTPSocket::send_data(byte* b, size_t length, bandwidth_type_t type, uint32 
 	int flags2 = b1->type();
 	uint16 seq_nr = b1->seq_nr;
 	uint16 ack_nr = b1->ack_nr;
-	log(UTP_LOG_DEBUG, "send %s len:%u id:%u timestamp:"I64u" reply_micro:%u flags:%s seq_nr:%u ack_nr:%u",
+	log(UTP_LOG_DEBUG, "send %s len:%u id:%u timestamp:" I64u " reply_micro:%u flags:%s seq_nr:%u ack_nr:%u",
 		addrfmt(addr, addrbuf), (uint)length, conn_id_send, time, reply_micro, flagnames[flags2],
 		seq_nr, ack_nr);
 #endif
@@ -1780,7 +1780,7 @@ size_t utp_process_incoming(UTPSocket *conn, const byte *packet, size_t len, boo
 	if (pk_flags >= ST_NUM_STATES) return 0;
 
 	#if UTP_DEBUG_LOGGING
-	conn->log(UTP_LOG_DEBUG, "Got %s. seq_nr:%u ack_nr:%u state:%s timestamp:"I64u" reply_micro:%u"
+	conn->log(UTP_LOG_DEBUG, "Got %s. seq_nr:%u ack_nr:%u state:%s timestamp:" I64u " reply_micro:%u"
 		, flagnames[pk_flags], pk_seq_nr, pk_ack_nr, statenames[conn->state]
 		, uint64(pf1->tv_usec), (uint32)(pf1->reply_micro));
 	#endif


### PR DESCRIPTION
This adds bittorrent/libutp/pull/66 and bittorrent/libutp/pull/96 into our branch.

Important note: this PR must not be squashed or rebased: it shall be merged without squashing/rebasing:
- if we squash or rebase, we lose the bittorrent ancestors and that may result in future conflicts
- if we merge, we keep the bittorrent ancestors and that will save us headaches to keep being aligned with them later