### PR TITLE
Revert "Make utp.h header C89-compliant"

### DIFF
--- a/include/libutp/utp.h
+++ b/include/libutp/utp.h
@@ -110,12 +110,12 @@ typedef struct {
 		int sample_ms;
 		int error_code;
 		int state;
-	} u1;
+	};
 
 	union {
 		socklen_t address_len;
 		int type;
-	} u2;
+	};
 } utp_callback_arguments;
 
 typedef uint64 utp_callback_t(utp_callback_arguments *);

--- a/ucat.c
+++ b/ucat.c
@@ -208,7 +208,7 @@ uint64 callback_on_accept(utp_callback_arguments *a)
 
 uint64 callback_on_error(utp_callback_arguments *a)
 {
-	fprintf(stderr, "Error: %s\n", utp_error_code_names[a->u1.error_code]);
+	fprintf(stderr, "Error: %s\n", utp_error_code_names[a->error_code]);
 	utp_close(s);
 	s = NULL;
 	quit_flag = 1;
@@ -218,10 +218,10 @@ uint64 callback_on_error(utp_callback_arguments *a)
 
 uint64 callback_on_state_change(utp_callback_arguments *a)
 {
-	debug("state %d: %s\n", a->u1.state, utp_state_names[a->u1.state]);
+	debug("state %d: %s\n", a->state, utp_state_names[a->state]);
 	utp_socket_stats *stats;
 
-	switch (a->u1.state) {
+	switch (a->state) {
 		case UTP_STATE_CONNECT:
 		case UTP_STATE_WRITABLE:
 			write_data();
@@ -261,7 +261,7 @@ uint64 callback_on_state_change(utp_callback_arguments *a)
 
 uint64 callback_sendto(utp_callback_arguments *a)
 {
-	struct sockaddr_in *sin = (struct sockaddr_in *) a->u1.address;
+	struct sockaddr_in *sin = (struct sockaddr_in *) a->address;
 
 	debug("sendto: %zd byte packet to %s:%d%s\n", a->len, inet_ntoa(sin->sin_addr), ntohs(sin->sin_port),
 				(a->flags & UTP_UDP_DONTFRAG) ? "  (DF bit requested, but not yet implemented)" : "");
@@ -269,7 +269,7 @@ uint64 callback_sendto(utp_callback_arguments *a)
 	if (o_debug >= 3)
 		hexdump(a->buf, a->len);
 
-	sendto(fd, a->buf, a->len, 0, a->u1.address, a->u2.address_len);
+	sendto(fd, a->buf, a->len, 0, a->address, a->address_len);
 	return 0;
 }
 

--- a/utp_callbacks.cpp
+++ b/utp_callbacks.cpp
@@ -31,8 +31,8 @@ int utp_call_on_firewall(utp_context *ctx, const struct sockaddr *address, sockl
 	args.callback_type = UTP_ON_FIREWALL;
 	args.context = ctx;
 	args.socket = NULL;
-	args.u1.address = address;
-	args.u2.address_len = address_len;
+	args.address = address;
+	args.address_len = address_len;
 	return (int)ctx->callbacks[UTP_ON_FIREWALL](&args);
 }
 
@@ -43,8 +43,8 @@ void utp_call_on_accept(utp_context *ctx, utp_socket *socket, const struct socka
 	args.callback_type = UTP_ON_ACCEPT;
 	args.context = ctx;
 	args.socket = socket;
-	args.u1.address = address;
-	args.u2.address_len = address_len;
+	args.address = address;
+	args.address_len = address_len;
 	ctx->callbacks[UTP_ON_ACCEPT](&args);
 }
 
@@ -65,7 +65,7 @@ void utp_call_on_error(utp_context *ctx, utp_socket *socket, int error_code)
 	args.callback_type = UTP_ON_ERROR;
 	args.context = ctx;
 	args.socket = socket;
-	args.u1.error_code = error_code;
+	args.error_code = error_code;
 	ctx->callbacks[UTP_ON_ERROR](&args);
 }
 
@@ -88,9 +88,9 @@ void utp_call_on_overhead_statistics(utp_context *ctx, utp_socket *socket, int s
 	args.callback_type = UTP_ON_OVERHEAD_STATISTICS;
 	args.context = ctx;
 	args.socket = socket;
-	args.u1.send = send;
+	args.send = send;
 	args.len = len;
-	args.u2.type = type;
+	args.type = type;
 	ctx->callbacks[UTP_ON_OVERHEAD_STATISTICS](&args);
 }
 
@@ -101,7 +101,7 @@ void utp_call_on_delay_sample(utp_context *ctx, utp_socket *socket, int sample_m
 	args.callback_type = UTP_ON_DELAY_SAMPLE;
 	args.context = ctx;
 	args.socket = socket;
-	args.u1.sample_ms = sample_ms;
+	args.sample_ms = sample_ms;
 	ctx->callbacks[UTP_ON_DELAY_SAMPLE](&args);
 }
 
@@ -112,7 +112,7 @@ void utp_call_on_state_change(utp_context *ctx, utp_socket *socket, int state)
 	args.callback_type = UTP_ON_STATE_CHANGE;
 	args.context = ctx;
 	args.socket = socket;
-	args.u1.state = state;
+	args.state = state;
 	ctx->callbacks[UTP_ON_STATE_CHANGE](&args);
 }
 
@@ -123,8 +123,8 @@ uint16 utp_call_get_udp_mtu(utp_context *ctx, utp_socket *socket, const struct s
 	args.callback_type = UTP_GET_UDP_MTU;
 	args.context = ctx;
 	args.socket = socket;
-	args.u1.address = address;
-	args.u2.address_len = address_len;
+	args.address = address;
+	args.address_len = address_len;
 	return (uint16)ctx->callbacks[UTP_GET_UDP_MTU](&args);
 }
 
@@ -135,8 +135,8 @@ uint16 utp_call_get_udp_overhead(utp_context *ctx, utp_socket *socket, const str
 	args.callback_type = UTP_GET_UDP_OVERHEAD;
 	args.context = ctx;
 	args.socket = socket;
-	args.u1.address = address;
-	args.u2.address_len = address_len;
+	args.address = address;
+	args.address_len = address_len;
 	return (uint16)ctx->callbacks[UTP_GET_UDP_OVERHEAD](&args);
 }
 
@@ -200,8 +200,8 @@ void utp_call_sendto(utp_context *ctx, utp_socket *socket, const byte *buf, size
 	args.socket = socket;
 	args.buf = buf;
 	args.len = len;
-	args.u1.address = address;
-	args.u2.address_len = address_len;
+	args.address = address;
+	args.address_len = address_len;
 	args.flags = flags;
 	ctx->callbacks[UTP_SENDTO](&args);
 }

--- a/utp_utils.cpp
+++ b/utp_utils.cpp
@@ -232,13 +232,13 @@ static inline uint64 UTP_GetMicroseconds()
 uint64 utp_default_get_udp_mtu(utp_callback_arguments *args) {
 	// Since we don't know the local address of the interface,
 	// be conservative and assume all IPv6 connections are Teredo.
-	return (args->u1.address->sa_family == AF_INET6) ? UDP_TEREDO_MTU : UDP_IPV4_MTU;
+	return (args->address->sa_family == AF_INET6) ? UDP_TEREDO_MTU : UDP_IPV4_MTU;
 }
 
 uint64 utp_default_get_udp_overhead(utp_callback_arguments *args) {
 	// Since we don't know the local address of the interface,
 	// be conservative and assume all IPv6 connections are Teredo.
-	return (args->u1.address->sa_family == AF_INET6) ? UDP_TEREDO_OVERHEAD : UDP_IPV4_OVERHEAD;
+	return (args->address->sa_family == AF_INET6) ? UDP_TEREDO_OVERHEAD : UDP_IPV4_OVERHEAD;
 }
 
 uint64 utp_default_get_random(utp_callback_arguments * /*args*/) {


### PR DESCRIPTION
This reverts commit 6748011df47980f22a01a2247491c609b3e3dc1c.

See: transmission/transmission#4750