### PR TITLE
refactor: use std::vector instead of bespoke Array class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(LIBUTP_STANDALONE_BUILD)
     endif()
 
     if(NOT CMAKE_CXX_STANDARD)
-        set(CMAKE_CXX_STANDARD 98)
+        set(CMAKE_CXX_STANDARD 17)
         set(CMAKE_CXX_STANDARD_REQUIRED ON)
         set(CMAKE_CXX_EXTENSIONS OFF)
     endif()

--- a/utp_hash.cpp
+++ b/utp_hash.cpp
@@ -20,6 +20,8 @@
  * THE SOFTWARE.
  */
 
+#include <assert.h>
+
 #include "utp_hash.h"
 #include "utp_types.h"
 

--- a/utp_internal.h
+++ b/utp_internal.h
@@ -28,6 +28,8 @@
 #include <assert.h>
 #include <stdio.h>
 
+#include <vector>
+
 #include "utp.h"
 #include "utp_callbacks.h"
 #include "utp_templates.h"
@@ -59,6 +61,16 @@ enum bandwidth_type_t {
 #endif
 
 struct PACKED_ATTRIBUTE RST_Info {
+	RST_Info() = default;
+
+  RST_Info(PackedSockAddr _addr, uint32 _connid, uint16 _ack_nr, uint64 _timestamp)
+		: addr{ _addr }
+		, connid{ _connid }
+		, ack_nr{ _ack_nr }
+		, timestamp{ _timestamp }
+	{
+	}
+
 	PackedSockAddr addr;
 	uint32 connid;
 	uint16 ack_nr;
@@ -117,8 +129,8 @@ struct struct_utp_context {
 	uint64 current_ms;
 	utp_context_stats context_stats;
 	UTPSocket *last_utp_socket;
-	Array<UTPSocket*> ack_sockets;
-	Array<RST_Info> rst_info;
+	std::vector<UTPSocket*> ack_sockets;
+	std::vector<RST_Info> rst_info;
 	UTPSocketHT *utp_sockets;
 	size_t target_delay;
 	size_t opt_sndbuf;

--- a/utp_templates.h
+++ b/utp_templates.h
@@ -24,7 +24,6 @@
 #define __TEMPLATES_H__
 
 #include "utp_types.h"
-#include <assert.h>
 
 #if defined(POSIX)
 /* Allow over-writing FORCEINLINE from makefile because gcc 3.4.4 for buffalo
@@ -94,102 +93,5 @@ typedef big_endian<uint16> uint16_big;
 #endif
 
 template<typename T> static inline void zeromem(T *a, size_t count = 1) { memset(a, 0, count * sizeof(T)); }
-
-typedef int SortCompareProc(const void *, const void *);
-
-template<typename T> static FORCEINLINE void QuickSortT(T *base, size_t num, int (*comp)(const T *, const T *)) { qsort(base, num, sizeof(T), (SortCompareProc*)comp); }
-
-
-// WARNING: The template parameter MUST be a POD type!
-template <typename T, size_t minsize = 16> class Array {
-protected:
-	T *mem;
-	size_t alloc,count;
-
-public:
-	Array(size_t init) { Init(init); }
-	Array() { Init(); }
-	~Array() { Free(); }
-
-	void inline Init() { mem = NULL; alloc = count = 0; }
-	void inline Init(size_t init) { Init(); if (init) Resize(init); }
-	size_t inline GetCount() const { return count; }
-	size_t inline GetAlloc() const { return alloc; }
-	void inline SetCount(size_t c) { count = c; }
-
-	inline T& operator[](size_t offset) { assert(offset ==0 || offset<alloc); return mem[offset]; }
-	inline const T& operator[](size_t offset) const { assert(offset ==0 || offset<alloc); return mem[offset]; }
-
-	void inline Resize(size_t a) {
-		if (a == 0) { free(mem); Init(); }
-		else { mem = (T*)realloc(mem, (alloc=a) * sizeof(T)); }
-	}
-
-	void Grow() { Resize(::max<size_t>(minsize, alloc * 2)); }
-
-	inline size_t Append(const T &t) {
-		if (count >= alloc) Grow();
-		size_t r=count++;
-		mem[r] = t;
-		return r;
-	}
-
-	T inline &Append() {
-		if (count >= alloc) Grow();
-		return mem[count++];
-	}
-
-	void inline Compact() {
-		Resize(count);
-	}
-
-	void inline Free() {
-		free(mem);
-		Init();
-	}
-
-	void inline Clear() {
-		count = 0;
-	}
-
-	bool inline MoveUpLast(size_t index) {
-		assert(index < count);
-		size_t c = --count;
-		if (index != c) {
-			mem[index] = mem[c];
-			return true;
-		}
-		return false;
-	}
-
-	bool inline MoveUpLastExist(const T &v) {
-		return MoveUpLast(LookupElementExist(v));
-	}
-
-	size_t inline LookupElement(const T &v) const {
-		for(size_t i = 0; i != count; i++)
-			if (mem[i] == v)
-				return i;
-		return (size_t) -1;
-	}
-
-	bool inline HasElement(const T &v) const {
-		return LookupElement(v) != -1;
-	}
-
-	typedef int SortCompareProc(const T *a, const T *b);
-
-	void Sort(SortCompareProc* proc, size_t start, size_t end) {
-		QuickSortT(&mem[start], end - start, proc);
-	}
-
-	void Sort(SortCompareProc* proc, size_t start) {
-		Sort(proc, start, count);
-	}
-
-	void Sort(SortCompareProc* proc) {
-		Sort(proc, 0, count);
-	}
-};
 
 #endif //__TEMPLATES_H__


### PR DESCRIPTION
Part one of a three-part series to use `std::` tools instead of bespoke ones.  Part three will fix https://github.com/transmission/libutp/issues/6.

- [x] Part 1: #7
- [x] Part 2: #12
- [x] Part 3: #13

Unfortunately there don't seem to be any real tests for libutp, so the need to manually test is even greater than usual.
