### PR TITLE
fix: malformed logs produced by `struct_utp_context::log()`

### DIFF
--- a/utp_internal.cpp
+++ b/utp_internal.cpp
@@ -3388,21 +3388,26 @@ void struct_utp_context::log(int level, utp_socket *socket, char const *fmt, ...
 
 	va_list va;
 	va_start(va, fmt);
-	log_unchecked(socket, fmt, va);
+	log_impl(socket, fmt, va);
 	va_end(va);
 }
 
 void struct_utp_context::log_unchecked(utp_socket *socket, char const *fmt, ...)
 {
 	va_list va;
+	va_start(va, fmt);
+	log_impl(socket, fmt, va);
+	va_end(va);
+}
+
+void struct_utp_context::log_impl(utp_socket *socket, char const *fmt, va_list va)
+{
 	char buf[4096];
 
-	va_start(va, fmt);
 	vsnprintf(buf, 4096, fmt, va);
 	buf[4095] = '\0';
-	va_end(va);
 
-	utp_call_log(this, socket, (const byte *)buf);
+	utp_call_log(this, socket, reinterpret_cast<const byte *>(buf));
 }
 
 inline bool struct_utp_context::would_log(int level)

--- a/utp_internal.h
+++ b/utp_internal.h
@@ -182,6 +182,9 @@ struct struct_utp_context {
 	bool log_normal:1;	// log normal events?
 	bool log_mtu:1;		// log MTU related events?
 	bool log_debug:1;	// log debugging events? (Must also compile with UTP_DEBUG_LOGGING defined)
+
+private:
+	void log_impl(utp_socket *socket, char const *fmt, va_list va);
 };
 
 #endif //__UTP_INTERNAL_H__


### PR DESCRIPTION
For example for this line of log:

https://github.com/transmission/libutp/blob/52645d6d0fb16009e11d2f84469d2e43b7b6b48a/utp_internal.cpp#L2853

Base64-encoded incoming packet payload: `EQMwowBy1L11syXMABAAAK3z2V0ABAAAAAY=`

Expected log:

```
recv {addrport string} len:26 version:0 unsupported version
```

Actual log:

```
recv   len:4294967295 version:8191 unsupported version
```
